### PR TITLE
fix: `token` is unused

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -31,7 +31,6 @@ jobs:
       - run: pnpm build:debug
       - run: node ./dist
         env:
-          INPUT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           INPUT_TEMPLATE: |-
             {{#each metrics}}{{name}},{{type}},{{value}},{{ddtags tags}}
             {{/each}}

--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ jobs:
     steps:
       - uses: oakcask/issue-metrics-action@v1
         with:
-          token: "${{ secrets.GITHUB_TOKEN }}"
           # This is a example to generate StatsD format with tags.
           # (Note that tags are Datadog extension)
           #

--- a/action.yaml
+++ b/action.yaml
@@ -2,11 +2,6 @@ name: issue-metrics-action
 description: collect and export issue metrics
 author: oakcask
 inputs:
-  token:
-    required: false
-    description: |-
-      The repository's secret to authorize API invocations.
-      If ommited, GITHUB_TOKEN environment variable is used instead.
   tag-labels:
     required: false
     description: |-


### PR DESCRIPTION
follows up https://github.com/oakcask/issue-metrics-action/pull/2