### PR TITLE
doc: widen event coverage

### DIFF
--- a/.github/workflows/example--statsd.yaml
+++ b/.github/workflows/example--statsd.yaml
@@ -1,7 +1,24 @@
 name: example / statsd
 on:
   issues:
+    types:
+      - opened
+      - edited
+      - deleted
+      - transferred
+      - closed
+      - reopened
   pull_request:
+    types:
+      - assigned
+      - unassigned
+      - opened
+      - edited
+      - closed
+      - reopened
+      - synchronize
+      - ready_for_review
+      - converted_to_draft
 jobs:
   export:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -8,7 +8,24 @@ Generate metric on triggered issues or pull requests event.
 name: example / statsd
 on:
   issues:
+    types:
+      - opened
+      - edited
+      - deleted
+      - transferred
+      - closed
+      - reopened
   pull_request:
+    types:
+      - assigned
+      - unassigned
+      - opened
+      - edited
+      - closed
+      - reopened
+      - synchronize
+      - ready_for_review
+      - converted_to_draft
 jobs:
   export:
     runs-on: ubuntu-latest


### PR DESCRIPTION
To record meaningful metrics of activities, the default activity types triggered for events of issue and pull request are too narrow.
This pull request widens the coverage of event activity type for a workflow example.